### PR TITLE
Add .NET workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,90 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "master", "workflows" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-and-pack:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.set_tag_name.outputs.tag_name }}
+    strategy:
+      matrix:
+        dotnet-version: [ '5.0.x', '6.0.x' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.11
+        with:
+          versionSpec: '5.x'
+
+      - name: Calculate version with GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.11
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build project
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run tests
+        run: dotnet test --no-build --configuration Release --logger "trx;LogFileName=test_results.xml"
+
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ steps.gitversion.outputs.SemVer }} --output ./nupkgs/${{ matrix.dotnet-version }}
+
+      - name: Upload NuGet package artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.dotnet-version }}
+          path: ./nupkgs/${{ matrix.dotnet-version }}/*.nupkg
+
+      - name: Set tag_name Output
+        id: set_tag_name
+        run: echo "tag_name=${{ steps.gitversion.outputs.SemVer }}" >> $GITHUB_OUTPUT
+
+  create-and-upload-release:
+    needs: build-and-pack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./nupkgs
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.build-and-pack.outputs.tag_name }}
+          release_name: Release ${{ needs.build-and-pack.outputs.tag_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload NuGet packages to release
+        run: |
+          for file in ./nupkgs/*/*.nupkg; do
+            cp "$file" "./nupkgs/"
+            
+            echo "Uploading $(basename "$file") to release..."
+            gh release upload ${{ needs.build-and-pack.outputs.tag_name }} "$file" --repo ${{ github.repository }}
+            
+            break # ugly 
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,18 +6,26 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  DOTNET_VERSION: '6.0.x'
+
 jobs:
-  build-test-pack-release:
+  build:
     runs-on: ubuntu-latest
+
+    outputs:
+      semVer: ${{ steps.gitversion.outputs.SemVer }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.11
@@ -28,29 +36,90 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.11
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Build project
         run: dotnet build --no-restore --configuration Release
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            **/bin
+            **/obj
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+
       - name: Run tests
         run: dotnet test --no-build --configuration Release --logger "trx;LogFileName=test_results.xml"
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: "**/TestResults"
+
+  nuget:
+    if: github.event_name == 'push'
+    needs: [build, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - name: Create NuGet package
-        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ steps.gitversion.outputs.SemVer }} --output ./nupkgs
+        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ needs.build.outputs.semVer }} --output ./nupkgs
 
       - name: Push NuGet package
         run: |
           dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
-          dotnet nuget push -k ${{ secrets.GITHUB_TOKEN }} -s github ./nupkgs/*.nupkg
+          dotnet nuget push --skip-duplicate -k ${{ secrets.GITHUB_TOKEN }} -s github ./nupkgs/*.nupkg
 
+  release:
+    if: github.event_name == 'push'
+    needs: [build, test, nuget]
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Create release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.gitversion.outputs.SemVer }}
-          release_name: Release ${{ steps.gitversion.outputs.SemVer }}
+          tag_name: ${{ needs.build.outputs.semVer }}
+          release_name: Release ${{ needs.build.outputs.semVer }}
           draft: false
           prerelease: false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,22 +7,17 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-and-test:
+  build-test-pack-release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '5.0.x', '6.0.x' ]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: '6.0.x'
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.11
@@ -42,36 +37,20 @@ jobs:
       - name: Run tests
         run: dotnet test --no-build --configuration Release --logger "trx;LogFileName=test_results.xml"
 
-      - name: Set tag_name Output
-        id: set_tag_name
-        run: echo "tag_name=${{ steps.gitversion.outputs.SemVer }}" >> $GITHUB_OUTPUT
-
-  pack-and-release:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '6.0.x'
-
-      - name: Dotnet pack
-        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ needs.build-and-test.outputs.tag_name }} --output ./nupkgs
+      - name: Create NuGet package
+        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ steps.gitversion.outputs.SemVer }} --output ./nupkgs
 
       - name: Push NuGet package
         run: |
-         dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
-         dotnet nuget push -k ${{ secrets.GITHUB_TOKEN }} -s github ./nupkgs/*.nupkg
+          dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
+          dotnet nuget push -k ${{ secrets.GITHUB_TOKEN }} -s github ./nupkgs/*.nupkg
 
       - name: Create release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.build-and-test.outputs.tag_name }}
-          release_name: Release ${{ needs.build-and-test.outputs.tag_name }}
+          tag_name: ${{ steps.gitversion.outputs.SemVer }}
+          release_name: Release ${{ steps.gitversion.outputs.SemVer }}
           draft: false
           prerelease: false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,15 +76,10 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload NuGet packages to release
+      - name: Add NuGet Source
+        run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
+
+      - name: Push NuGet packages to GitHub Packages
         run: |
-          for file in ./nupkgs/*/*.nupkg; do
-            cp "$file" "./nupkgs/"
-            
-            echo "Uploading $(basename "$file") to release..."
-            gh release upload ${{ needs.build-and-pack.outputs.tag_name }} "$file" --repo ${{ github.repository }}
-            
-            break # ugly 
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          newestSubDir=$(ls -td -- ${GITHUB_WORKSPACE}/nupkgs/*/ | head -n 1)
+          dotnet nuget push -k ${{ secrets.GITHUB_TOKEN }} -s github $(ls ${newestSubDir}*.nupkg | head -n 1)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,10 +7,8 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-and-pack:
+  build-and-test:
     runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.set_tag_name.outputs.tag_name }}
     strategy:
       matrix:
         dotnet-version: [ '5.0.x', '6.0.x' ]
@@ -44,42 +42,36 @@ jobs:
       - name: Run tests
         run: dotnet test --no-build --configuration Release --logger "trx;LogFileName=test_results.xml"
 
-      - name: Pack
-        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ steps.gitversion.outputs.SemVer }} --output ./nupkgs/${{ matrix.dotnet-version }}
-
-      - name: Upload NuGet package artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.dotnet-version }}
-          path: ./nupkgs/${{ matrix.dotnet-version }}/*.nupkg
-
       - name: Set tag_name Output
         id: set_tag_name
         run: echo "tag_name=${{ steps.gitversion.outputs.SemVer }}" >> $GITHUB_OUTPUT
 
-  create-and-upload-release:
-    needs: build-and-pack
+  pack-and-release:
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
         with:
-          path: ./nupkgs
+          dotnet-version: '6.0.x'
+
+      - name: Dotnet pack
+        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ needs.build-and-test.outputs.tag_name }} --output ./nupkgs
+
+      - name: Push NuGet package
+        run: |
+         dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
+         dotnet nuget push -k ${{ secrets.GITHUB_TOKEN }} -s github ./nupkgs/*.nupkg
 
       - name: Create release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.build-and-pack.outputs.tag_name }}
-          release_name: Release ${{ needs.build-and-pack.outputs.tag_name }}
+          tag_name: ${{ needs.build-and-test.outputs.tag_name }}
+          release_name: Release ${{ needs.build-and-test.outputs.tag_name }}
           draft: false
           prerelease: false
-
-      - name: Add NuGet Source
-        run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
-
-      - name: Push NuGet packages to GitHub Packages
-        run: |
-          newestSubDir=$(ls -td -- ${GITHUB_WORKSPACE}/nupkgs/*/ | head -n 1)
-          dotnet nuget push -k ${{ secrets.GITHUB_TOKEN }} -s github $(ls ${newestSubDir}*.nupkg | head -n 1)


### PR DESCRIPTION

This PR introduces up a CI/CD pipeline using GitHub Actions, triggered by pushes to the master and workflows branches. It includes steps for compiling, testing, and packaging the project, culminating in the automated deployment of packages to NuGet, streamlining the process for code validation and release management.

### Jobs overview
#### build: 
Sets up .NET, uses [GitVersion](https://gitversion.net/) for semantic versioning, builds the project, caches NuGet packages, and uploads artifacts.

#### test: 
Runs after build, downloads artifacts, executes tests, and uploads results.

#### nuget: 
Post build and test, repackages artifacts into NuGet packages with the version from GitVersion, and uploads to GitHub Package Registry. This step requires no additional setup post-merge and can be modified to push to nuget.org by changing the NuGet feed URL and API key.

#### release: 
Creates a GitHub release with the version from the build job.

### Highlights:
- Repository/Organisation Agnostic: No extra configuration needed post-merger.
- Automated Semantic Versioning: Leveraging GitVersion for meaningful versioning.

- Flexible Package Publishing: Default setup for GitHub Package Registry, easily switchable to nuget.org by updating the feed URL and API key in the nuget job.